### PR TITLE
Update script options handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,7 +358,7 @@ GEM
     websocket-extensions (0.1.5)
     whenever (1.0.0)
       chronic (>= 0.6.3)
-    wikibase_representable (0.1.4)
+    wikibase_representable (0.2.1)
       multi_json (~> 1.15)
       representable (~> 3.2)
     xpath (3.2.0)

--- a/lib/wikibase_to_solr.rb
+++ b/lib/wikibase_to_solr.rb
@@ -74,7 +74,7 @@ File.open(output_file, 'w') do |file|
     solr_item = base_solr_item(meta)
 
     [meta.holding, meta.manuscript, meta.record].each do |item|
-      item.claims.each do |property_id, claims|
+      item.claims_hash.each do |property_id, claims|
         claims.each do |claim|
           next unless DigitalScriptorium::Transformers.defined? property_id
 

--- a/lib/wikibase_to_solr.rb
+++ b/lib/wikibase_to_solr.rb
@@ -7,28 +7,32 @@ require 'time'
 require 'zlib'
 
 dir = File.dirname __FILE__
-
-input_file = File.expand_path 'wikibase_export.json.gz', dir
-output_file = File.expand_path 'solr_import.json', dir
-pretty_print = false
-
 logger = Logging.logger($stdout)
+
+options = {}
 
 OptionParser.new { |opts|
   opts.banner = 'Usage: wikibase_to_solr.rb [options]'
 
   opts.on('-i', '--in FILE', 'The file path to the gzipped Wikibase JSON export file.') do |f|
-    input_file = File.expand_path f, dir
+    options[:input_file] = File.expand_path f, dir
   end
 
   opts.on('-o', '--out FILE', 'The file path to output the formatted Solr JSON file.') do |f|
-    output_file = File.expand_path f, dir
+    options[:output_file] = File.expand_path f, dir
   end
 
   opts.on('-p', '--pretty-print', 'Whether to pretty-print the JSON output.') do
-    pretty_print = true
+    options[:pretty_print] = true
   end
 }.parse!
+
+abort('Input file (-i) is required.') unless options[:input_file]
+abort('Output file (-o) is required.') unless options[:output_file]
+
+input_file = options[:input_file]
+output_file = options[:output_file]
+pretty_print = options[:pretty_print]
 
 def merge(solr_item, new_props)
   solr_item.merge(new_props) do |_, old_val, new_val|


### PR DESCRIPTION
Add command line options to an empty hash rather than setting defaults which can be overridden. Abort if input and output file are not set.